### PR TITLE
Logon rewrite

### DIFF
--- a/OfficeKeyFix.cpp
+++ b/OfficeKeyFix.cpp
@@ -3,6 +3,69 @@
 #include <thread>
 #include <chrono>
 #include <iostream>
+#include <tlhelp32.h>
+
+// via https://stackoverflow.com/a/24646860
+DWORD FindProcessId(char* processName)
+{
+    // strip path
+    char* p = strrchr(processName, '\\');
+    if(p)
+        processName = p+1;
+
+    PROCESSENTRY32 processInfo;
+    processInfo.dwSize = sizeof(processInfo);
+
+    HANDLE processesSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, NULL);
+    if ( processesSnapshot == INVALID_HANDLE_VALUE )
+        return 0;
+
+    Process32First(processesSnapshot, &processInfo);
+    if ( !strcmp(processName, processInfo.szExeFile) )
+    {
+        CloseHandle(processesSnapshot);
+        return processInfo.th32ProcessID;
+    }
+
+    while ( Process32Next(processesSnapshot, &processInfo) )
+    {
+        if ( !strcmp(processName, processInfo.szExeFile) )
+        {
+          CloseHandle(processesSnapshot);
+          return processInfo.th32ProcessID;
+        }
+    }
+
+    CloseHandle(processesSnapshot);
+    return 0;
+}
+
+int WaitForProcessExit(int pid)
+{
+	HANDLE h=OpenProcess(SYNCHRONIZE , true, pid);
+	if (!h) {
+		// Already not running
+		return 0;
+	}
+	WaitForSingleObject(h, INFINITE );
+	return 1; // Was running, but no longer
+}
+
+void Takeover(UINT offendingKeys[])
+{
+	//Register hotkey
+	for (int i = 0; i < 10; i++) {
+		RegisterHotKey(NULL, i, 0x1 + 0x2 + 0x4 + 0x8 | MOD_NOREPEAT, offendingKeys[i]);
+	}
+}
+
+void Relinquish()
+{
+	//deregister hotkeys by ID
+	for (int i = 0; i < 10; i++) {
+		UnregisterHotKey(NULL, i);
+	}
+}
 
 int main(int argc, wchar_t* argv[])
 {
@@ -10,26 +73,30 @@ int main(int argc, wchar_t* argv[])
 	//These map to W, T, Y, O, P, D, L, X, N, and Space, respectively.
 	UINT offendingKeys[10] = { 0x57, 0x54, 0x59, 0x4F, 0x50, 0x44, 0x4C, 0x58, 0x4E, 0x20 };
 
-	//Kill Explorer
-	system("taskkill /IM explorer.exe /F");
+	while ( true )
+	{
+		Takeover(offendingKeys);
+	
+		// Wait for Explorer to start
+		until ( pid = FindProcessId("explorer.exe") )
+		{
+			// Only check for Explorer once a second
+			std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+		}
+	
+		/* Sleep for a few seconds to make sure Explorer has time to
+		   attempt to register the Office hotkeys, and get blocked by 
+	   	   our hotkeys */
+		std::this_thread::sleep_for(std::chrono::milliseconds(4000));
 
-	//Register hotkey
-	for (int i = 0; i < 10; i++) {
-		RegisterHotKey(NULL, i, 0x1 + 0x2 + 0x4 + 0x8 | MOD_NOREPEAT, offendingKeys[i]);
+		Relinquish();
+		
+		// Wait for Explorer to exit
+		WaitForProcessExit(pid);
+		// Then do it all over again, forever
+		// Hey, it's better than passing butter
 	}
 
-	//Restart Explorer
-	system("start C:/Windows/explorer.exe");
-
-	/* Sleep for a few seconds to make sure Explorer has time to
-	   attempt to register the Office hotkeys, and get blocked by 
-	   our hotkeys */
-	std::this_thread::sleep_for(std::chrono::milliseconds(4000));
-	 
-	//deregister hotkeys by ID
-	for (int i = 0; i < 10; i++) {
-		UnregisterHotKey(NULL, i);
-	}
-
+	// Currently unreachable, perhaps add a single loop commandline option?
 	return 1;
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # OfficeKeyFix
 
-Unbinds the Office Key (Shift+Control+Alt+Win) related shortcuts, allowing you to use Office+W in other applications.
+Unbinds the Office Key AKA "Hyper" or "HYPR" (Shift+Control+Alt+Win) related shortcuts, allowing you to use those shortcuts in other applications.
 
-You'll need to compile the script into a binary, and place it in `C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Startup` so it will run on startup.
+You will also need to disable the default Office launcher with this command:
+`REG ADD HKCU\Software\Classes\ms-officeapp\Shell\Open\Command /t REG_SZ /d rundll32`
+Note that is a per-user setting. If you are aware of a global registry key to make this change please let me know.
+
+To manage this as a Windows Service at logon, you can use [NSSM](https://nssm.cc/download) or similar. You will need NSSM 2.2.4-101 or later on Windows 10.


### PR DESCRIPTION
No longer kills Explorer, instead attempts to register hotkeys immediately and then waits for Explorer to start before freeing them. If Explorer dies for any reason it will register the hotkeys again until it is restarted.

This handles the additional situation where Explorer crashes and ensures it doesn't reclaim shortcuts when it restarts.

This variant can be run at logon and it will handle things from there. Alternatively, you can run this variant from the desktop and then manually restart explorer in Task Manager to get the same effect. It will then continue to monitor Explorer for crashes.